### PR TITLE
Make build/lib dir in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ class CustomBuildPy(build_py.build_py, object):
     def run(self):
         super(CustomBuildPy, self).run()
         subprocess.check_call("make", shell=True)
+        subprocess.check_call("mkdir -p build/lib/", shell=True)
         subprocess.check_call("cp -r bin data build/lib/", shell=True)
 
 


### PR DESCRIPTION
Per previous conversations, it seems that `srtm4` was not `pip install`able on some platforms.

For example, the following Dockerfile:

```Dockerfile
FROM ubuntu:xenial

RUN apt-get update && apt-get install -y \
    build-essential \
    curl \
    libtiff-dev \
    python-dev \
    python-numpy

RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
    python get-pip.py && \
    rm get-pip.py

RUN pip install srtm4
```

crashes with the current `sdist` of `srtm4` (`1.1.0`):

<details><summary>expand error traceback</summary><p>

```
Building wheel for srtm4 (setup.py): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-Rlws_f/srtm4/setup.py'"'"'; __file__='"'"'/tmp/pip-install-Rlws_f/srtm4/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-7D_JpK --python-tag cp27
       cwd: /tmp/pip-install-Rlws_f/srtm4/
  Complete output (50 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-2.7
  copying srtm4.py -> build/lib.linux-x86_64-2.7
  running egg_info
  writing requirements to srtm4.egg-info/requires.txt
  writing srtm4.egg-info/PKG-INFO
  writing top-level names to srtm4.egg-info/top_level.txt
  writing dependency_links to srtm4.egg-info/dependency_links.txt
  reading manifest file 'srtm4.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  warning: no files found matching 'requirements.txt'
  writing manifest file 'srtm4.egg-info/SOURCES.txt'
  mkdir -p bin
  g++ -g -O3 -fpermissive -DNDEBUG -DDONT_USE_TEST_MAIN -c src/Geoid.cpp -o src/Geoid.o
  g++ -g -O3 -fpermissive -DNDEBUG -DDONT_USE_TEST_MAIN -c src/geoid_height_wrapper.cpp -o src/geoid_height_wrapper.o
  cc -std=c99 -g -O3 -DNDEBUG -DDONT_USE_TEST_MAIN -DMAIN_SRTM4 src/srtm4.c src/Geoid.o src/geoid_height_wrapper.o -lstdc++ -lz -lm -ltiff -o bin/srtm4
  cc -std=c99 -g -O3 -DNDEBUG -DDONT_USE_TEST_MAIN -DMAIN_SRTM4_WHICH_TILE src/srtm4.c src/Geoid.o src/geoid_height_wrapper.o -lstdc++ -lz -lm -ltiff -o bin/srtm4_which_tile
  cp: target 'build/lib/' is not a directory
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-install-Rlws_f/srtm4/setup.py", line 53, in <module>
      zip_safe=False)
    File "/usr/local/lib/python2.7/dist-packages/setuptools/__init__.py", line 145, in setup
      return distutils.core.setup(**attrs)
    File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
      dist.run_commands()
    File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
      self.run_command(cmd)
    File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
      cmd_obj.run()
    File "/usr/local/lib/python2.7/dist-packages/wheel/bdist_wheel.py", line 192, in run
      self.run_command('build')
    File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
      self.distribution.run_command(command)
    File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
      cmd_obj.run()
    File "/usr/lib/python2.7/distutils/command/build.py", line 128, in run
      self.run_command(cmd_name)
    File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
      self.distribution.run_command(command)
    File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
      cmd_obj.run()
    File "/tmp/pip-install-Rlws_f/srtm4/setup.py", line 29, in run
      subprocess.check_call("cp -r bin data build/lib/", shell=True)
    File "/usr/lib/python2.7/subprocess.py", line 541, in check_call
      raise CalledProcessError(retcode, cmd)
  subprocess.CalledProcessError: Command 'cp -r bin data build/lib/' returned non-zero exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for srtm4
```

</p></details>

The command that fails is `cp -r bin data build/lib/`, so this PR adds a line in the `setup.py` to make this directory if it does not exist.

It fixes the Dockerfile case above, I hope it doesn't break anything else...