### PR TITLE
allow setting compiler flags so that a custom installation location for libtiff can be supported

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,7 +1,7 @@
 C99 = $(CC) -std=c99
-CFLAGS = -g -O3 -DNDEBUG -DDONT_USE_TEST_MAIN
-CPPFLAGS = -g -O3 -fpermissive -DNDEBUG -DDONT_USE_TEST_MAIN
-LDLIBS = -lstdc++ -lz -lm -ltiff
+CFLAGS = -g -O3 -DNDEBUG -DDONT_USE_TEST_MAIN {cflags}
+CPPFLAGS = -g -O3 -fpermissive -DNDEBUG -DDONT_USE_TEST_MAIN {cppflags}
+LDLIBS = -lstdc++ -lz -lm -ltiff {ldlibs}
 
 default: bin bin/srtm4 bin/srtm4_which_tile
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,16 @@ from codecs import open
 from setuptools import setup
 from setuptools.command import develop, build_py
 
+def _createMakefile():
+    template = open('Makefile.in').read()
+    cflags = os.environ.get('CFLAGS', '')
+    cppflags = os.environ.get('CPPFLAGS', '')
+    ldlibs = os.environ.get('LDLIBS', '')
+    content = template.format(**locals())
+    open('Makefile', 'wt').write(content)
+    return
+_createMakefile()
+
 
 def readme():
     with open('README.md', 'r', 'utf-8') as f:


### PR DESCRIPTION
This is an attempt to allow users to set compiler flags when running setup.py, so that a custom installation location for `libtiff` can be handled. This can be useful, for example, when installing srtm4 under a conda environment (where libtiff was installed using conda). For example, after this change, I was able to  run `python setup.py build` in a conda environment by 

```
export LDLIBS="-L $CONDA_PREFIX/lib"
export CFLAGS="-I $CONDA_PREFIX/include"
python setup.py build
```