### PR TITLE
Requests retry

### DIFF
--- a/srtm4.py
+++ b/srtm4.py
@@ -126,7 +126,7 @@ def get_srtm_tile(srtm_tile, out_dir):
         return
 
     if os.path.exists(zip_path):
-        print ('zip already exists')
+        print('zip already exists')
         # Only possibility here is that the previous process was cut short
 
     try:


### PR DESCRIPTION
This PR implements retry logic to the `get` call performed to retrieve zip files from a server.

The server seems to give 503 responses when it is overloaded with requests (this can be easily demonstrated by performing 10 simultaneous requests to a single zip), but these error responses are intermittent so a simple retry with exponential back-off generally solves them.

The retry logic is implemented using a `requests.Session` to which an `HTTPAdapter` with `Retry` has been mounted. Retries are only done on 5xx codes. If the server still gives a 5xx code after 5 retries, the `session.get()` call will raise a `RetryError`.

I have also added a check on the status code of the response, in case the server doesn't reply 200 nor 5xx, in which case a `ConnectionError` is raised.

Both of these errors are caught and re-raised in the call to the `download` function, in order to release the `lock_zip` that was acquired (otherwise, the code hangs as it cannot acquire the lock for other zips).

You can try out the functionality by hardcoding `from_url` in `download()` to:
- https://httpstat.us/404
- https://httpstat.us/503

and running `pytest`.
Notice the two different errors being raised.